### PR TITLE
Fix clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatdata"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["boxdot <d@zerovolt.org>"]
 license = "MIT/Apache-2.0"
 description = "Rust implementation of heremaps/flatdata"

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -187,9 +187,9 @@ macro_rules! define_struct {
         impl ::std::fmt::Debug for $name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 write!(f,
-                    concat!("{} {{ ",
+                    concat!(stringify!($name), " {{ ",
                         intersperse!($(concat!( stringify!($field), ": {}")), *), " }}"),
-                    stringify!($name), $(self.$field(),)*)
+                    $(self.$field(),)*)
             }
         }
 
@@ -309,8 +309,8 @@ macro_rules! define_variadic_struct {
             fn from((type_index, data): ($crate::TypeIndex, *const u8)) -> Self {
                 match type_index {
                     $($type_index => $name::$type($type::from(data))),+,
-                    _ => panic!(
-                        "invalid type index {} for type {}", type_index, stringify!($name)),
+                    _ => panic!(concat!(
+                        "invalid type index {} for type ", stringify!($name)), type_index),
                 }
             }
         }
@@ -450,7 +450,7 @@ macro_rules! define_archive {
         impl ::std::fmt::Debug for $name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 write!(f,
-                    concat!("{} {{ ",
+                    concat!(stringify!($name), " {{ ",
                         intersperse!(""
                             $(, concat!(stringify!($struct_resource), ": {:?}"))*
                             $(, concat!(stringify!($vector_resource), ": {:?}"))*
@@ -460,13 +460,12 @@ macro_rules! define_archive {
                             $(, concat!(stringify!($opt_subarchive_resource), ": {:?}"))*
                         ),
                     " }}"),
-                    stringify!($name)
-                    $(, self.$struct_resource())*
-                    $(, self.$vector_resource())*
-                    $(, self.$multivector_resource())*
-                    $(, self.$raw_data_resource)*
-                    $(, self.$subarchive_resource)*
-                    $(, self.$opt_subarchive_resource)*
+                    $(self.$struct_resource(), )*
+                    $(self.$vector_resource(), )*
+                    $(self.$multivector_resource(), )*
+                    $(self.$raw_data_resource, )*
+                    $(self.$subarchive_resource, )*
+                    $(self.$opt_subarchive_resource, )*
                 )
             }
         }
@@ -628,5 +627,26 @@ macro_rules! define_archive {
                 Ok(Self { storage })
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::structbuf::StructBuf;
+
+    #[test]
+    #[allow(dead_code)]
+    fn test_debug() {
+        define_struct!(
+            A,
+            AMut,
+            "no_schema",
+            4,
+            (x, set_x, u32, 0, 16),
+            (y, set_y, u32, 16, 16)
+        );
+        let a = StructBuf::<A>::new();
+        let output = format!("{:?}", a);
+        assert_eq!(output, "StructBuf { resource: A { x: 0, y: 0 } }");
     }
 }

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -259,7 +259,7 @@ macro_rules! define_struct {
 
         impl ::std::convert::AsRef<$name> for $name_mut {
             fn as_ref(&self) -> &$name {
-                unsafe { ::std::mem::transmute(&self) }
+                unsafe { &*(self as *const $name_mut as *const $name) }
             }
         }
      }

--- a/src/bytereader.rs
+++ b/src/bytereader.rs
@@ -24,7 +24,7 @@ macro_rules! read_bytes {
     }};
     ($T:tt, $data:expr, $offset:expr, $num_bits:expr) => {{
         let bytes: *const u8 = $data;
-        assert!(!bytes.is_null(), "Reading uninitialized structure");
+        debug_assert!(!bytes.is_null(), "Reading uninitialized structure");
         let mut reader: *const u8 = unsafe { bytes.offset($offset / 8) };
         let mut bits_left = $num_bits;
         let local_offset = $offset % 8;

--- a/src/bytewriter.rs
+++ b/src/bytewriter.rs
@@ -12,7 +12,7 @@ macro_rules! masked {
 #[macro_export]
 macro_rules! num_bytes {
     ($offset:expr, $num_bits:expr) => {
-        if $num_bits + $offset % 8 <= 64 {
+        if $num_bits + $offset % 8 < 64 {
             ($num_bits + $offset % 8 + 7) / 8
         } else {
             ($num_bits + 7) / 8
@@ -45,7 +45,7 @@ macro_rules! num_bytes {
 #[macro_export]
 macro_rules! write_bytes {
     ($T:tt; $value:expr, $data:expr, $offset:expr, $num_bits:expr) => {{
-        assert!($num_bits <= 64, "num_bits cannot be > 64");
+        debug_assert!($num_bits <= 64, "num_bits cannot be > 64");
 
         let destination = &mut $data[$offset / 8] as *mut u8;
         let bit_offset = $offset % 8;


### PR DESCRIPTION
Fixes all clippy warnings coming from the macros. This is especially problematic, since clippy warnings propagate to the users of flatdata.