### PR TITLE
Make (Multi)Vector drop a bit more sane

### DIFF
--- a/src/multivector.rs
+++ b/src/multivector.rs
@@ -193,20 +193,12 @@ where
     /// Flushes the remaining not yet flushed elements in this multivector and
     /// finalizes the data inside the storage.
     ///
-    /// After this method is called, more data cannot be written into this
-    /// multivector. A multivector *must* be closed, otherwise it will
-    /// panic on drop (in debug mode).
-    pub fn close(&mut self) -> io::Result<()> {
+    /// A multivector *must* be closed, otherwise it will panic on drop
+    pub fn close(mut self) -> io::Result<()> {
         self.add_to_index()?; // sentinel for last item
-        self.index.close()?;
         self.flush()?;
+        self.index.close()?;
         self.data_handle.borrow_mut().close()
-    }
-}
-
-impl<Idx, Ts> Drop for MultiVector<Idx, Ts> {
-    fn drop(&mut self) {
-        debug_assert!(!self.data_handle.is_open(), "MultiVector not closed")
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -374,3 +374,24 @@ fn write_padding(stream: &mut Stream) -> io::Result<()> {
     let zeroes: [u8; PADDING_SIZE] = [0; PADDING_SIZE];
     stream.write_all(&zeroes)
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    #[should_panic]
+    fn test_panick_on_leak() {
+        let stream = Rc::new(RefCell::new(Cursor::new(Vec::new())));
+        let _h = ResourceHandle::new(stream);
+        // leak h without closing it -> should panic
+    }
+
+    #[test]
+    fn test_not_panick_on_close() -> io::Result<()> {
+        let stream = Rc::new(RefCell::new(Cursor::new(Vec::new())));
+        let mut h = ResourceHandle::new(stream)?;
+        h.close()
+    }
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -13,6 +13,7 @@ use std::ptr;
 use std::rc::Rc;
 use std::slice;
 use std::str;
+use std::thread;
 
 pub trait Stream: Write + Seek {}
 
@@ -312,6 +313,15 @@ impl ResourceHandle {
         }
         self.stream = None;
         Ok(())
+    }
+}
+
+impl Drop for ResourceHandle {
+    fn drop(&mut self) {
+        if !thread::panicking() {
+            // Only panic in case we are dropping the handle normally
+            assert!(!self.is_open(), "Resource not closed");
+        }
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -338,18 +338,10 @@ where
     /// Flushes the remaining not yet flushed elements in this vector and
     /// finalizes the data inside the storage.
     ///
-    /// After this method is called, more data cannot be written into this
-    /// vector. An external vector *must* be closed, otherwise it will
-    /// panic on drop (in debug mode).
-    pub fn close(&mut self) -> io::Result<()> {
+    /// An external vector *must* be closed, otherwise it will panic on drop
+    pub fn close(mut self) -> io::Result<()> {
         self.flush()?;
         self.resource_handle.borrow_mut().close()
-    }
-}
-
-impl<T> Drop for ExternalVector<T> {
-    fn drop(&mut self) {
-        debug_assert!(!self.resource_handle.is_open(), "ExternalVector not closed")
     }
 }
 


### PR DESCRIPTION
* Panick only if no other panick is in flight
* close takes self by move to reflect that you should not use instance anymore after