### PR TITLE
Allow references to outlive the iterators/views they come from

### DIFF
--- a/src/multiarrayview.rs
+++ b/src/multiarrayview.rs
@@ -68,9 +68,9 @@ where
     }
 
     /// Returns an iterator through the indexed items of the array.
-    pub fn iter(&'a self) -> MultiArrayViewIter<Idx, Ts> {
+    pub fn iter(&self) -> MultiArrayViewIter<'a, Idx, Ts> {
         MultiArrayViewIter {
-            view: self,
+            view: self.clone(),
             next_pos: 0,
         }
     }
@@ -88,7 +88,7 @@ where
     _phantom: marker::PhantomData<&'a Ts>,
 }
 
-impl<'a, Ts> iter::Iterator for MultiArrayViewItemIter<'a, Ts>
+impl<'a, Ts: 'a> iter::Iterator for MultiArrayViewItemIter<'a, Ts>
 where
     Ts: for<'b> VariadicStruct<'b>,
 {
@@ -139,11 +139,11 @@ where
     Idx: for<'b> IndexStruct<'b>,
     Ts: for<'b> VariadicStruct<'b>,
 {
-    view: &'a MultiArrayView<'a, Idx, Ts>,
+    view: MultiArrayView<'a, Idx, Ts>,
     next_pos: usize,
 }
 
-impl<'a, Idx, Ts> iter::Iterator for MultiArrayViewIter<'a, Idx, Ts>
+impl<'a, Idx: 'a, Ts: 'a> iter::Iterator for MultiArrayViewIter<'a, Idx, Ts>
 where
     Idx: for<'b> IndexStruct<'b>,
     Ts: for<'b> VariadicStruct<'b>,
@@ -160,7 +160,7 @@ where
     }
 }
 
-impl<'a, Idx, Ts> iter::ExactSizeIterator for MultiArrayViewIter<'a, Idx, Ts>
+impl<'a, Idx: 'a, Ts: 'a> iter::ExactSizeIterator for MultiArrayViewIter<'a, Idx, Ts>
 where
     Idx: for<'b> IndexStruct<'b>,
     Ts: for<'b> VariadicStruct<'b>,

--- a/src/multivector.rs
+++ b/src/multivector.rs
@@ -288,6 +288,28 @@ mod tests {
             }
         }
 
-        let _mv_copy = mv.clone();
+        let x = {
+            // test clone and lifetime of returned reference
+            let mv_copy = mv.clone();
+            mv_copy.at(0).next().unwrap()
+        };
+        match x {
+            RefVariant::A(ref a) => {
+                assert_eq!(a.x(), 1);
+                assert_eq!(a.y(), 2);
+            }
+        }
+
+        let x = {
+            // test clone and lifetime of returned reference
+            let mv_copy = mv.clone();
+            mv_copy.iter().next().unwrap().next().unwrap()
+        };
+        match x {
+            RefVariant::A(ref a) => {
+                assert_eq!(a.x(), 1);
+                assert_eq!(a.y(), 2);
+            }
+        }
     }
 }


### PR DESCRIPTION
This make using views/iterators much easier: The user can treat them exactly like what they are: non-owning views.

Now:
- References can outlive views
- References can outlive iterators
- Iterators can outlive views