### PR TITLE
Return views on closing streaming containers

### DIFF
--- a/src/filestorage.rs
+++ b/src/filestorage.rs
@@ -42,17 +42,17 @@ pub struct FileResourceStorage {
 
 impl FileResourceStorage {
     /// Create an empty memory mapped file storage.
-    pub fn new(path: path::PathBuf) -> Self {
-        Self {
+    pub fn new(path: path::PathBuf) -> Rc<Self> {
+        Rc::new(Self {
             storage: MemoryMappedFileStorage::default(),
             path,
-        }
+        })
     }
 }
 
 impl ResourceStorage for FileResourceStorage {
-    fn subdir(&self, dir: &str) -> Rc<RefCell<ResourceStorage>> {
-        Rc::new(RefCell::new(Self::new(self.path.join(dir))))
+    fn subdir(&self, dir: &str) -> Rc<ResourceStorage> {
+        Self::new(self.path.join(dir))
     }
 
     fn exists(&self, resource_name: &str) -> bool {

--- a/src/memstorage.rs
+++ b/src/memstorage.rs
@@ -37,19 +37,19 @@ pub struct MemoryResourceStorage {
 
 impl MemoryResourceStorage {
     /// Create an empty memory resource storage.
-    pub fn new(path: path::PathBuf) -> Self {
-        Self {
+    pub fn new(path: path::PathBuf) -> Rc<Self> {
+        Rc::new(Self {
             storage: MemoryStorage::default(),
             path,
-        }
+        })
     }
 }
 
 impl Stream for Cursor<Vec<u8>> {}
 
 impl ResourceStorage for MemoryResourceStorage {
-    fn subdir(&self, dir: &str) -> Rc<RefCell<ResourceStorage>> {
-        Rc::new(RefCell::new(Self::new(self.path.join(dir))))
+    fn subdir(&self, dir: &str) -> Rc<ResourceStorage> {
+        Self::new(self.path.join(dir))
     }
 
     fn exists(&self, resource_name: &str) -> bool {

--- a/src/multivector.rs
+++ b/src/multivector.rs
@@ -74,7 +74,7 @@ use std::marker;
 /// let mut storage = MemoryResourceStorage::new("/root/multivec".into());
 /// {
 ///     let mut mv = create_multi_vector::<Idx, AB>(
-///             &mut storage, "multivector", "some schema")
+///             &*storage, "multivector", "some schema")
 ///         .expect("failed to create MultiVector");
 ///     {
 ///         let mut item = mv.grow().expect("grow failed");
@@ -126,21 +126,21 @@ use std::marker;
 /// [`ExternalVector`]: struct.ExternalVector.html
 /// [`Vector`]: struct.Vector.html
 /// [`MultiArrayView`]: struct.MultiArrayView.html
-pub struct MultiVector<Idx, Ts> {
-    index: ExternalVector<Idx>,
+pub struct MultiVector<'a, Idx, Ts> {
+    index: ExternalVector<'a, Idx>,
     data: Vec<u8>,
-    data_handle: ResourceHandle,
+    data_handle: ResourceHandle<'a>,
     size_flushed: usize,
     _phantom: marker::PhantomData<Ts>,
 }
 
-impl<Idx, Ts> MultiVector<Idx, Ts>
+impl<'a, Idx, Ts> MultiVector<'a, Idx, Ts>
 where
     Idx: for<'b> IndexStruct<'b>,
     Ts: for<'b> VariadicStruct<'b>,
 {
     /// Creates an empty multivector.
-    pub fn new(index: ExternalVector<Idx>, data_handle: ResourceHandle) -> Self {
+    pub fn new(index: ExternalVector<'a, Idx>, data_handle: ResourceHandle<'a>) -> Self {
         Self {
             index,
             data: vec![0; memory::PADDING_SIZE],
@@ -202,7 +202,7 @@ where
     }
 }
 
-impl<Idx, Ts: VariadicRef> fmt::Debug for MultiVector<Idx, Ts>
+impl<'a, Idx, Ts: VariadicRef> fmt::Debug for MultiVector<'a, Idx, Ts>
 where
     Idx: for<'b> IndexStruct<'b>,
     Ts: for<'b> VariadicStruct<'b>,
@@ -237,10 +237,10 @@ mod tests {
 
     #[test]
     fn test_multi_vector() {
-        let mut storage = MemoryResourceStorage::new("/root/resources".into());
+        let storage = MemoryResourceStorage::new("/root/resources".into());
         {
             let mut mv =
-                create_multi_vector::<Idx, Variant>(&mut storage, "multivector", "Some schema")
+                create_multi_vector::<Idx, Variant>(&*storage, "multivector", "Some schema")
                     .expect("failed to create MultiVector");
             {
                 let mut item = mv.grow().expect("grow failed");

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -237,9 +237,9 @@ where
 ///     (y, set_y, u32, 16, 16)
 /// );
 ///
-/// let mut storage = MemoryResourceStorage::new("/root/extvec".into());
+/// let storage = MemoryResourceStorage::new("/root/extvec".into());
 /// {
-///     let mut v = create_external_vector::<A>(&mut storage, "vector", "Some schema content")
+///     let mut v = create_external_vector::<A>(&*storage, "vector", "Some schema content")
 ///         .expect("failed to create ExternalVector");
 ///     {
 ///         let mut a = v.grow().expect("grow failed");
@@ -269,19 +269,19 @@ where
 /// ```
 ///
 /// [`grow`]: #method.grow
-pub struct ExternalVector<T> {
+pub struct ExternalVector<'a, T> {
     data: Vec<u8>,
     len: usize,
-    resource_handle: ResourceHandle,
+    resource_handle: ResourceHandle<'a>,
     _phantom: marker::PhantomData<T>,
 }
 
-impl<T> ExternalVector<T>
+impl<'a, T> ExternalVector<'a, T>
 where
     T: for<'b> Struct<'b>,
 {
     /// Creates an empty `ExternalVector<T>` in the given resource storage.
-    pub fn new(resource_handle: ResourceHandle) -> Self {
+    pub fn new(resource_handle: ResourceHandle<'a>) -> Self {
         Self {
             data: vec![0; memory::PADDING_SIZE],
             len: 0,
@@ -345,7 +345,7 @@ where
     }
 }
 
-impl<T> fmt::Debug for ExternalVector<T>
+impl<'a, T> fmt::Debug for ExternalVector<'a, T>
 where
     T: for<'b> Struct<'b>,
 {


### PR DESCRIPTION
Should enable more memory-efficient construction of flatdata libraries in case data needs to be read during construction itself.

Adapts #10 to the lifetime changes done since then.