### PR TITLE
Fix clippy warnings for the crate and macros used by clients.

### DIFF
--- a/src/bytereader.rs
+++ b/src/bytereader.rs
@@ -27,7 +27,7 @@ macro_rules! read_bytes {
 
         let bytes: *const u8 = $data;
         debug_assert!(!bytes.is_null(), "Reading uninitialized structure");
-        let data: *const u8 = unsafe { bytes.offset(byte_offset as isize) };
+        let data: *const u8 = unsafe { bytes.add(byte_offset) };
 
         if $num_bits == 1 {
             (unsafe { *data } & (1 << bit_offset) != 0) as $T
@@ -39,7 +39,7 @@ macro_rules! read_bytes {
             result >>= bit_offset;
 
             if num_bytes * 8 - bit_offset < $num_bits {
-                let temp = u64::from(unsafe { *data.offset((byte_offset + num_bytes) as isize) });
+                let temp = u64::from(unsafe { *data.add(byte_offset + num_bytes) });
                 result |= temp << (num_bytes * 8 - bit_offset) % (num_bytes * 8);
             }
             result = masked!(result, $num_bits);

--- a/src/filestorage.rs
+++ b/src/filestorage.rs
@@ -42,6 +42,7 @@ pub struct FileResourceStorage {
 
 impl FileResourceStorage {
     /// Create an empty memory mapped file storage at a given path.
+    #[allow(clippy::new_ret_no_self)]
     pub fn new<P: Into<PathBuf>>(path: P) -> Rc<Self> {
         Rc::new(Self {
             storage: MemoryMappedFileStorage::default(),

--- a/src/memstorage.rs
+++ b/src/memstorage.rs
@@ -8,11 +8,13 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::slice;
 
+type MemoryStorageStream = Rc<RefCell<Cursor<Vec<u8>>>>;
+
 /// Internal storage of data in memory.
 #[derive(Default)]
 struct MemoryStorage {
     // Streams of resources that were written.
-    streams: RefCell<BTreeMap<PathBuf, Rc<RefCell<Cursor<Vec<u8>>>>>>,
+    streams: RefCell<BTreeMap<PathBuf, MemoryStorageStream>>,
     // Data of resources that were opened for reading.
     resources: RefCell<BTreeMap<PathBuf, Rc<Vec<u8>>>>,
 }
@@ -40,6 +42,7 @@ impl MemoryResourceStorage {
     ///
     /// Resources will be placed in ephemeral memory with prefix `path`. A path
     /// has to be provided to unify the interface with `FileResourceStorage`.
+    #[allow(clippy::new_ret_no_self)]
     pub fn new<P: Into<PathBuf>>(path: P) -> Rc<Self> {
         Rc::new(Self {
             storage: MemoryStorage::default(),

--- a/src/multiarrayview.rs
+++ b/src/multiarrayview.rs
@@ -94,7 +94,7 @@ where
 {
     type Item = <Ts as VariadicStruct<'a>>::Item;
     fn next(&mut self) -> Option<Self::Item> {
-        if self.data.len() > 0 {
+        if !self.data.is_empty() {
             let type_index = self.data[0];
             self.data = &self.data[1..];
             let res = <Ts as VariadicStruct>::create(type_index, &self.data);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -150,7 +150,8 @@ where
 
     // create external vector
     let data_writer = storage.create_output_stream(resource_name)?;
-    let handle = ResourceHandle::new(storage, resource_name.into(), schema.into(), data_writer)?;
+    let handle =
+        ResourceHandle::try_new(storage, resource_name.into(), schema.into(), data_writer)?;
     Ok(ExternalVector::new(handle))
 }
 
@@ -180,7 +181,8 @@ where
 
     // create multi vector
     let data_writer = storage.create_output_stream(resource_name)?;
-    let handle = ResourceHandle::new(storage, resource_name.into(), schema.into(), data_writer)?;
+    let handle =
+        ResourceHandle::try_new(storage, resource_name.into(), schema.into(), data_writer)?;
     Ok(MultiVector::new(index, handle))
 }
 
@@ -268,8 +270,13 @@ pub struct ResourceHandle<'a> {
 }
 
 impl<'a> ResourceHandle<'a> {
-    /// Create a new resource handle from a stream.
-    pub fn new(
+    /// Try to create a new resource handle from a stream.
+    ///
+    /// ## Errors
+    ///
+    /// Resource storage will try to reserve space in the beginning of the
+    /// stream for the size of the resource, will may result in an `io::Error`.
+    pub fn try_new(
         storage: &'a ResourceStorage,
         name: String,
         schema: String,
@@ -420,7 +427,7 @@ mod test {
             .unwrap();
 
         let stream = storage.create_output_stream("/root/extvec/blubb").unwrap();
-        let _h = ResourceHandle::new(
+        let _h = ResourceHandle::try_new(
             &*storage,
             "/root/extvec/blubb".into(),
             "myschema".into(),
@@ -443,7 +450,7 @@ mod test {
             .unwrap();
 
         let stream = storage.create_output_stream("/root/extvec/blubb").unwrap();
-        let mut h = ResourceHandle::new(
+        let mut h = ResourceHandle::try_new(
             &*storage,
             "/root/extvec/blubb".into(),
             "myschema".into(),


### PR DESCRIPTION
Note: fn new(...) -> Rc<Self> clippy warning is suppressed since it does not seem to be applicable here.