### PR TITLE
Better readability of HRTB

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -74,6 +74,12 @@ pub trait Struct<'a>: Clone {
     fn create_mut(data: &'a mut [u8]) -> Self::ItemMut;
 }
 
+/// Shortcut trait for Structs that are able to produce references of any given lifetime
+///
+/// Equivalent to ```for<'a> Struct<'a>'''
+pub trait RefFactory: for<'a> Struct<'a> {}
+impl<T> RefFactory for T where T: for<'a> Struct<'a> {}
+
 /// A specialized Struct factory producing Index items.
 /// Used primarily by the MultiVector/MultiArrayView.
 pub trait IndexStruct<'a>: Struct<'a> {
@@ -83,6 +89,12 @@ pub trait IndexStruct<'a>: Struct<'a> {
     /// Provide setter for index
     fn set_index(data: Self::ItemMut, value: usize);
 }
+
+/// Shortcut trait for IndexStructs that are able to produce references of any given lifetime
+///
+/// Equivalent to ```for<'a> IndexStruct<'a>'''
+pub trait IndexRefFactory: for<'a> IndexStruct<'a> {}
+impl<T> IndexRefFactory for T where T: for<'a> IndexStruct<'a> {}
 
 /// A type in archive used as index of a `MultiArrayView`.
 pub trait Index: Ref {}
@@ -128,6 +140,12 @@ pub trait VariadicStruct<'a>: Clone {
     /// Creates a builder for a list of VariadicRef.
     fn create_mut(data: &'a mut Vec<u8>) -> Self::ItemMut;
 }
+
+/// Shortcut trait for VariadicStructs that are able to produce references of any given lifetime
+///
+/// Equivalent to ```for<'a> VariadicStruct<'a>'''
+pub trait VariadicRefFactory: for<'a> VariadicStruct<'a> {}
+impl<T> VariadicRefFactory for T where T: for<'a> VariadicStruct<'a> {}
 
 /// A flatdata archive representing serialized data.
 ///

--- a/src/arrayview.rs
+++ b/src/arrayview.rs
@@ -1,4 +1,4 @@
-use crate::archive::Struct;
+use crate::archive::{RefFactory, Struct};
 use crate::vector::Vector;
 
 use std::fmt;
@@ -52,7 +52,7 @@ use std::ops::{Bound, RangeBounds};
 #[derive(Clone)]
 pub struct ArrayView<'a, T>
 where
-    T: for<'b> Struct<'b>,
+    T: RefFactory,
 {
     data: &'a [u8],
     _phantom: marker::PhantomData<T>,
@@ -60,7 +60,7 @@ where
 
 impl<'a, T> ArrayView<'a, T>
 where
-    T: for<'b> Struct<'b>,
+    T: RefFactory,
 {
     /// Creates a new `ArrayView` to the data at the given address.
     ///
@@ -130,7 +130,7 @@ where
 
 impl<'a, T> From<&'a Vector<T>> for ArrayView<'a, T>
 where
-    T: for<'b> Struct<'b>,
+    T: RefFactory,
 {
     fn from(v: &'a Vector<T>) -> Self {
         v.as_view()
@@ -143,7 +143,7 @@ pub(crate) fn debug_format<'a, T>(
     f: &mut fmt::Formatter,
 ) -> fmt::Result
 where
-    T: for<'b> Struct<'b>,
+    T: RefFactory,
 {
     let len = iter.len();
     let preview: Vec<_> = iter.take(super::DEBUG_PREVIEW_LEN).collect();
@@ -163,7 +163,7 @@ where
 
 impl<'a, T> fmt::Debug for ArrayView<'a, T>
 where
-    T: for<'b> Struct<'b>,
+    T: RefFactory,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         debug_format("ArrayView", self.iter(), f)
@@ -172,7 +172,7 @@ where
 
 impl<'a, T> IntoIterator for ArrayView<'a, T>
 where
-    T: for<'b> Struct<'b>,
+    T: RefFactory,
 {
     type Item = <ArrayViewIter<'a, T> as Iterator>::Item;
     type IntoIter = ArrayViewIter<'a, T>;
@@ -184,7 +184,7 @@ where
 
 impl<'a, T> IntoIterator for &ArrayView<'a, T>
 where
-    T: for<'b> Struct<'b>,
+    T: RefFactory,
 {
     type Item = <ArrayViewIter<'a, T> as Iterator>::Item;
     type IntoIter = ArrayViewIter<'a, T>;
@@ -196,7 +196,7 @@ where
 
 impl<'a, T> AsRef<[u8]> for ArrayView<'a, T>
 where
-    T: for<'b> Struct<'b>,
+    T: RefFactory,
 {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
@@ -207,14 +207,14 @@ where
 #[derive(Clone)]
 pub struct ArrayViewIter<'a, T>
 where
-    T: for<'b> Struct<'b>,
+    T: RefFactory,
 {
     view: ArrayView<'a, T>,
 }
 
 impl<'a, T> iter::Iterator for ArrayViewIter<'a, T>
 where
-    T: for<'b> Struct<'b>,
+    T: RefFactory,
 {
     type Item = <T as Struct<'a>>::Item;
     fn next(&mut self) -> Option<Self::Item> {
@@ -230,7 +230,7 @@ where
 
 impl<'a, T> iter::ExactSizeIterator for ArrayViewIter<'a, T>
 where
-    T: for<'b> Struct<'b>,
+    T: RefFactory,
 {
     fn len(&self) -> usize {
         self.view.len()
@@ -239,7 +239,7 @@ where
 
 impl<'a, T> iter::DoubleEndedIterator for ArrayViewIter<'a, T>
 where
-    T: for<'b> Struct<'b>,
+    T: RefFactory,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         if !self.view.is_empty() {
@@ -254,11 +254,11 @@ where
 }
 
 // we always check -> iterator is already fused
-impl<'a, T> iter::FusedIterator for ArrayViewIter<'a, T> where T: for<'b> Struct<'b> {}
+impl<'a, T> iter::FusedIterator for ArrayViewIter<'a, T> where T: RefFactory {}
 
 impl<'a, T> fmt::Debug for ArrayViewIter<'a, T>
 where
-    T: for<'b> Struct<'b>,
+    T: RefFactory,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         debug_format("ArrayViewIter", self.clone(), f)

--- a/src/multiarrayview.rs
+++ b/src/multiarrayview.rs
@@ -1,4 +1,6 @@
-use crate::archive::{IndexStruct, VariadicRef, VariadicStruct};
+use crate::archive::{
+    IndexRefFactory, IndexStruct, VariadicRef, VariadicRefFactory, VariadicStruct,
+};
 use crate::arrayview::ArrayView;
 
 use std::fmt;
@@ -15,8 +17,8 @@ use std::ops::{Bound, RangeBounds};
 #[derive(Clone)]
 pub struct MultiArrayView<'a, Idx, Ts>
 where
-    Idx: for<'b> IndexStruct<'b>,
-    Ts: for<'b> VariadicStruct<'b>,
+    Idx: IndexRefFactory,
+    Ts: VariadicRefFactory,
 {
     index: ArrayView<'a, Idx>,
     data: &'a [u8],
@@ -25,8 +27,8 @@ where
 
 impl<'a, Idx, Ts> MultiArrayView<'a, Idx, Ts>
 where
-    Idx: for<'b> IndexStruct<'b>,
-    Ts: for<'b> VariadicStruct<'b>,
+    Idx: IndexRefFactory,
+    Ts: VariadicRefFactory,
 {
     /// Creates a new `MultiArrayView` to the data at the given address.
     ///
@@ -100,7 +102,7 @@ where
 #[derive(Clone)]
 pub struct MultiArrayViewItemIter<'a, Ts>
 where
-    Ts: for<'b> VariadicStruct<'b>,
+    Ts: VariadicRefFactory,
 {
     data: &'a [u8],
     _phantom: marker::PhantomData<&'a Ts>,
@@ -108,7 +110,7 @@ where
 
 impl<'a, Ts> iter::Iterator for MultiArrayViewItemIter<'a, Ts>
 where
-    Ts: for<'b> VariadicStruct<'b>,
+    Ts: VariadicRefFactory,
 {
     type Item = <Ts as VariadicStruct<'a>>::Item;
     fn next(&mut self) -> Option<Self::Item> {
@@ -125,14 +127,11 @@ where
 }
 
 // we always check -> iterator is already fused
-impl<'a, Ts> iter::FusedIterator for MultiArrayViewItemIter<'a, Ts> where
-    Ts: for<'b> VariadicStruct<'b>
-{
-}
+impl<'a, Ts> iter::FusedIterator for MultiArrayViewItemIter<'a, Ts> where Ts: VariadicRefFactory {}
 
 impl<'a, Ts> fmt::Debug for MultiArrayViewItemIter<'a, Ts>
 where
-    Ts: for<'b> VariadicStruct<'b>,
+    Ts: VariadicRefFactory,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let preview: Vec<_> = self.clone().collect();
@@ -146,8 +145,8 @@ fn debug_format<'a, Idx, Ts>(
     f: &mut fmt::Formatter,
 ) -> fmt::Result
 where
-    Idx: for<'b> IndexStruct<'b>,
-    Ts: for<'b> VariadicStruct<'b>,
+    Idx: IndexRefFactory,
+    Ts: VariadicRefFactory,
 {
     let len = iter.len();
     let preview: Vec<(usize, Vec<_>)> = iter
@@ -171,8 +170,8 @@ where
 
 impl<'a, Idx, Ts> fmt::Debug for MultiArrayView<'a, Idx, Ts>
 where
-    Idx: for<'b> IndexStruct<'b>,
-    Ts: for<'b> VariadicStruct<'b>,
+    Idx: IndexRefFactory,
+    Ts: VariadicRefFactory,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         debug_format("MultiArrayView", self.iter(), f)
@@ -181,8 +180,8 @@ where
 
 impl<'a, Idx, Ts: 'a> IntoIterator for MultiArrayView<'a, Idx, Ts>
 where
-    Idx: for<'b> IndexStruct<'b>,
-    Ts: for<'b> VariadicStruct<'b>,
+    Idx: IndexRefFactory,
+    Ts: VariadicRefFactory,
 {
     type Item = <MultiArrayViewIter<'a, Idx, Ts> as Iterator>::Item;
     type IntoIter = MultiArrayViewIter<'a, Idx, Ts>;
@@ -194,8 +193,8 @@ where
 
 impl<'a, Idx, Ts: 'a> IntoIterator for &MultiArrayView<'a, Idx, Ts>
 where
-    Idx: for<'b> IndexStruct<'b>,
-    Ts: for<'b> VariadicStruct<'b>,
+    Idx: IndexRefFactory,
+    Ts: VariadicRefFactory,
 {
     type Item = <MultiArrayViewIter<'a, Idx, Ts> as Iterator>::Item;
     type IntoIter = MultiArrayViewIter<'a, Idx, Ts>;
@@ -209,16 +208,16 @@ where
 #[derive(Clone)]
 pub struct MultiArrayViewIter<'a, Idx, Ts>
 where
-    Idx: for<'b> IndexStruct<'b>,
-    Ts: for<'b> VariadicStruct<'b>,
+    Idx: IndexRefFactory,
+    Ts: VariadicRefFactory,
 {
     view: MultiArrayView<'a, Idx, Ts>,
 }
 
 impl<'a, Idx, Ts> fmt::Debug for MultiArrayViewIter<'a, Idx, Ts>
 where
-    Idx: for<'b> IndexStruct<'b>,
-    Ts: for<'b> VariadicStruct<'b>,
+    Idx: IndexRefFactory,
+    Ts: VariadicRefFactory,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         debug_format("MultiArrayViewIter", self.clone(), f)
@@ -227,8 +226,8 @@ where
 
 impl<'a, Idx, Ts: 'a> iter::Iterator for MultiArrayViewIter<'a, Idx, Ts>
 where
-    Idx: for<'b> IndexStruct<'b>,
-    Ts: for<'b> VariadicStruct<'b>,
+    Idx: IndexRefFactory,
+    Ts: VariadicRefFactory,
 {
     type Item = MultiArrayViewItemIter<'a, Ts>;
     fn next(&mut self) -> Option<Self::Item> {
@@ -244,8 +243,8 @@ where
 
 impl<'a, Idx, Ts: 'a> iter::DoubleEndedIterator for MultiArrayViewIter<'a, Idx, Ts>
 where
-    Idx: for<'b> IndexStruct<'b>,
-    Ts: for<'b> VariadicStruct<'b>,
+    Idx: IndexRefFactory,
+    Ts: VariadicRefFactory,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         if !self.view.is_empty() {
@@ -262,15 +261,15 @@ where
 // we always check -> iterator is already fused
 impl<'a, Idx, Ts: 'a> iter::FusedIterator for MultiArrayViewIter<'a, Idx, Ts>
 where
-    Idx: for<'b> IndexStruct<'b>,
-    Ts: for<'b> VariadicStruct<'b>,
+    Idx: IndexRefFactory,
+    Ts: VariadicRefFactory,
 {
 }
 
 impl<'a, Idx, Ts: 'a> iter::ExactSizeIterator for MultiArrayViewIter<'a, Idx, Ts>
 where
-    Idx: for<'b> IndexStruct<'b>,
-    Ts: for<'b> VariadicStruct<'b>,
+    Idx: IndexRefFactory,
+    Ts: VariadicRefFactory,
 {
     fn len(&self) -> usize {
         self.view.len()

--- a/src/multivector.rs
+++ b/src/multivector.rs
@@ -1,4 +1,6 @@
-use crate::archive::{IndexStruct, VariadicRef, VariadicStruct};
+use crate::archive::{
+    IndexRefFactory, IndexStruct, VariadicRef, VariadicRefFactory, VariadicStruct,
+};
 use crate::error::ResourceStorageError;
 use crate::memory;
 use crate::multiarrayview::MultiArrayView;
@@ -128,7 +130,11 @@ use std::marker;
 /// [`ExternalVector`]: struct.ExternalVector.html
 /// [`Vector`]: struct.Vector.html
 /// [`MultiArrayView`]: struct.MultiArrayView.html
-pub struct MultiVector<'a, Idx, Ts> {
+pub struct MultiVector<'a, Idx, Ts>
+where
+    Idx: IndexRefFactory,
+    Ts: VariadicRefFactory,
+{
     index: ExternalVector<'a, Idx>,
     data: Vec<u8>,
     data_handle: ResourceHandle<'a>,
@@ -138,8 +144,8 @@ pub struct MultiVector<'a, Idx, Ts> {
 
 impl<'a, Idx, Ts> MultiVector<'a, Idx, Ts>
 where
-    Idx: for<'b> IndexStruct<'b>,
-    Ts: for<'b> VariadicStruct<'b>,
+    Idx: IndexRefFactory,
+    Ts: VariadicRefFactory,
 {
     /// Creates an empty multivector.
     pub fn new(index: ExternalVector<'a, Idx>, data_handle: ResourceHandle<'a>) -> Self {
@@ -209,8 +215,8 @@ where
 
 impl<'a, Idx, Ts: VariadicRef> fmt::Debug for MultiVector<'a, Idx, Ts>
 where
-    Idx: for<'b> IndexStruct<'b>,
-    Ts: for<'b> VariadicStruct<'b>,
+    Idx: IndexRefFactory,
+    Ts: VariadicRefFactory,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "MultiVector {{ len: {} }}", self.index.len())

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,4 +1,4 @@
-use crate::archive::Struct;
+use crate::archive::{RefFactory, Struct};
 use crate::arrayview::{debug_format, ArrayView};
 use crate::error::ResourceStorageError;
 
@@ -61,14 +61,17 @@ use std::marker;
 /// [`ExternalVector`]: struct.ExternalVector.html
 /// [`as_view`]: #method.as_view
 #[derive(Clone)]
-pub struct Vector<T> {
+pub struct Vector<T>
+where
+    T: RefFactory,
+{
     data: Vec<u8>,
     _phantom: marker::PhantomData<T>,
 }
 
 impl<T> Vector<T>
 where
-    T: for<'b> Struct<'b>,
+    T: RefFactory,
 {
     /// Creates an empty `Vector<T>`.
     #[inline]
@@ -163,7 +166,7 @@ where
 
 impl<T> Default for Vector<T>
 where
-    T: for<'b> Struct<'b>,
+    T: RefFactory,
 {
     /// Creates an empty `Vector<T>`.
     fn default() -> Self {
@@ -173,7 +176,7 @@ where
 
 impl<T> AsRef<[u8]> for Vector<T>
 where
-    T: for<'b> Struct<'b>,
+    T: RefFactory,
 {
     /// Returns the content of this vector as slice of bytes. Equivalent to
     /// [`as_bytes`].
@@ -186,7 +189,7 @@ where
 
 impl<T> fmt::Debug for Vector<T>
 where
-    T: for<'b> Struct<'b>,
+    T: RefFactory,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         debug_format("Vector", self.as_view().iter(), f)
@@ -263,7 +266,10 @@ where
 /// ```
 ///
 /// [`grow`]: #method.grow
-pub struct ExternalVector<'a, T> {
+pub struct ExternalVector<'a, T>
+where
+    T: RefFactory,
+{
     data: Vec<u8>,
     len: usize,
     resource_handle: ResourceHandle<'a>,
@@ -272,7 +278,7 @@ pub struct ExternalVector<'a, T> {
 
 impl<'a, T> ExternalVector<'a, T>
 where
-    T: for<'b> Struct<'b>,
+    T: RefFactory,
 {
     /// Creates an empty `ExternalVector<T>` in the given resource storage.
     pub fn new(resource_handle: ResourceHandle<'a>) -> Self {
@@ -345,7 +351,7 @@ where
 
 impl<T> fmt::Debug for ExternalVector<'_, T>
 where
-    T: for<'b> Struct<'b>,
+    T: RefFactory,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "ExternalVector {{ len: {} }}", self.len())


### PR DESCRIPTION
We used HRTB to create references for arbitrary lifetimes, but that led to the proliferation of ```for<'b> Trait<'b>```. This change introduces 3 aliases that can be used instead: ```RefFactory``` ```IndexRefFactory``` and ```VariadicRefFactory```